### PR TITLE
fix(nvim): shenannigans with completion in command mode

### DIFF
--- a/dotfiles/nvim/lazy-lock.json
+++ b/dotfiles/nvim/lazy-lock.json
@@ -3,7 +3,6 @@
   "Navigator.nvim": { "branch": "master", "commit": "91d86506ac2a039504d5205d32a1d4bc7aa57072" },
   "Vim-Jinja2-Syntax": { "branch": "master", "commit": "2c17843b074b06a835f88587e1023ceff7e2c7d1" },
   "cmp-buffer": { "branch": "main", "commit": "3022dbc9166796b644a841a02de8dd1cc1d311fa" },
-  "cmp-cmdline": { "branch": "main", "commit": "d250c63aa13ead745e3a40f61fdd3470efde3923" },
   "cmp-nvim-lsp": { "branch": "main", "commit": "39e2eda76828d88b773cc27a3f61d2ad782c922d" },
   "cmp-path": { "branch": "main", "commit": "91ff86cd9c29299a64f968ebb45846c485725f23" },
   "cmp_luasnip": { "branch": "master", "commit": "05a9ab28b53f71d1aece421ef32fee2cb857a843" },

--- a/dotfiles/nvim/lua/ik1614/plugins/completion.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/completion.lua
@@ -6,7 +6,6 @@ return {
       "hrsh7th/cmp-buffer",
       "hrsh7th/cmp-path",
       "hrsh7th/cmp-nvim-lsp",
-      "hrsh7th/cmp-cmdline",
       "onsails/lspkind.nvim",
       { "L3MON4D3/LuaSnip", build = "make install_jsregexp" },
       "saadparwaiz1/cmp_luasnip",
@@ -37,10 +36,10 @@ return {
         ["<C-c>"] = cmp.mapping.close(),
 
         -- Move to [N]ext item in completion menue
-        ["<C-n>"] = cmp.mapping(cmp.mapping.select_next_item({ behavior = cmp.SelectBehavior.Select }), { "i", "c" }),
+        ["<C-n>"] = cmp.mapping(cmp.mapping.select_next_item({ behavior = cmp.SelectBehavior.Select }), { "i" }),
 
         -- Move to previous item in completion menu
-        ["<C-e>"] = cmp.mapping(cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Select }), { "i", "c" }),
+        ["<C-e>"] = cmp.mapping(cmp.mapping.select_prev_item({ behavior = cmp.SelectBehavior.Select }), { "i" }),
 
         -- Scrolling [U]p / back
         ["<C-u>"] = cmp.mapping(cmp.mapping.scroll_docs(-4), { "i" }),
@@ -56,7 +55,7 @@ return {
             -- behavior = cmp.ConfirmBehavior.Replace,
             select = true,
           }),
-          { "i", "c" }
+          { "i" }
         ),
       }
 
@@ -82,26 +81,6 @@ return {
           }),
         },
       })
-
-      -- cmp.setup.cmdline('/', {
-      --   mapping = default_mappings,
-      --   sources = {
-      --     { name = 'buffer', keyword_length = 3 }
-      --   }
-      -- })
-      --
-      -- cmp.setup.cmdline(':', {
-      --   mapping = default_mappings,
-      --   sources = cmp.config.sources(
-      --     {
-      --       { name = 'path', keyword_length = 3 }
-      --     },
-      --     {
-      --       { name = 'cmdline', keyword_length = 3 }
-      --     }
-      --   ),
-      --   matching = { disallow_symbol_nonprefix_matching = false }
-      -- })
     end,
   },
 }


### PR DESCRIPTION
There were issues with item from the menu being selected after pressing `<CR>`, but then actually the first field from the menu would get executed 🤷 

Can come back to using `nvim-cmp` for `cmdline` at a later date.