### PR TITLE
chore(nvim): tweaks for quicker start up time 93.07ms -> 37.37ms

### DIFF
--- a/dotfiles/nvim/lua/ik1614/core/settings.lua
+++ b/dotfiles/nvim/lua/ik1614/core/settings.lua
@@ -64,6 +64,10 @@ vim.opt.lazyredraw = true -- don't bother updating screen during macro playback
 
 vim.opt.backspace = "indent,start,eol" -- allow unrestricted backspacing in insert mode, e.g. linebreaks, autoindent etc.
 
+-- NOTE: Recommended settings from `nvim-tree` documentation to disable `netrw` completely
+vim.g.loaded_netrw = 1
+vim.g.loaded_netrwPlugin = 1
+
 -- Copy to system wide clipboard
 -- vim.o.clipboard = "unnamed"
 vim.o.clipboard = "unnamedplus"

--- a/dotfiles/nvim/lua/ik1614/plugins/completion.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/completion.lua
@@ -1,7 +1,7 @@
 return {
   {
     "hrsh7th/nvim-cmp",
-    event = { "InsertEnter", "CmdlineEnter" },
+    event = { "InsertEnter" },
     dependencies = {
       "hrsh7th/cmp-buffer",
       "hrsh7th/cmp-path",

--- a/dotfiles/nvim/lua/ik1614/plugins/dap.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/dap.lua
@@ -1,5 +1,6 @@
 return {
   "mfussenegger/nvim-dap",
+  event = { "BufReadPre", "BufNewFile" },
   dependencies = {
     "rcarriga/nvim-dap-ui",
     "nvim-neotest/nvim-nio",

--- a/dotfiles/nvim/lua/ik1614/plugins/lsp.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/lsp.lua
@@ -13,6 +13,7 @@
 return {
   {
     "https://github.com/neovim/nvim-lspconfig",
+    event = { "BufReadPre", "BufNewFile" },
     dependencies = {
       { "https://github.com/williamboman/mason.nvim", config = true }, -- NOTE: Must be loaded before dependants
       { "https://github.com/williamboman/mason-lspconfig.nvim" },

--- a/dotfiles/nvim/lua/ik1614/plugins/nvim-tree.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/nvim-tree.lua
@@ -2,16 +2,15 @@ return {
   {
     "https://github.com/nvim-tree/nvim-tree.lua",
     enabled = true,
+    keys = {
+      { "<leader>ob", "<cmd>NvimTreeFindFile<CR>zz", mode = "n", desc = "[O]pen current file in a file [b]rowser" },
+    },
     event = {},
-    lazy = false,
+    -- lazy = false,
     dependencies = {
       "https://github.com/nvim-tree/nvim-web-devicons",
     },
     config = function()
-      -- NOTE: Recommended settings from nvim-tree documentation to disable `netrw` completely
-      vim.g.loaded_netrw = 1
-      vim.g.loaded_netrwPlugin = 1
-
       require("nvim-tree").setup({
         actions = {
           open_file = {
@@ -89,16 +88,6 @@ return {
           require_confirm = true,
         },
       })
-
-      -- set keymaps
-      local keymap = vim.keymap -- for conciseness
-
-      vim.keymap.set(
-        "n",
-        "<leader>ob",
-        "<cmd>NvimTreeFindFile<CR>zz",
-        { desc = "[O]pen current file in a file [b]rowser" }
-      ) -- toggle file explorer
     end,
   },
 }

--- a/dotfiles/nvim/lua/ik1614/plugins/snippets.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/snippets.lua
@@ -2,6 +2,7 @@ return {
   {
     "L3MON4D3/LuaSnip",
     enabled = true,
+    event = "InsertEnter",
     dependencies = {},
     build = "make install_jsregexp",
     config = function()

--- a/dotfiles/nvim/lua/ik1614/plugins/statusine.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/statusine.lua
@@ -2,6 +2,7 @@ return {
   {
     "https://github.com/nvim-lualine/lualine.nvim",
     enabled = true,
+    event = { "BufReadPre", "BufNewFile" },
     dependencies = {
       "https://github.com/nvim-tree/nvim-web-devicons",
     },

--- a/dotfiles/nvim/lua/ik1614/plugins/tmux-navigator.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/tmux-navigator.lua
@@ -2,24 +2,23 @@ return {
   {
     "https://github.com/numToStr/Navigator.nvim",
     enabled = true,
+    keys = {
+      { "<S-Down>", "<CMD>NavigatorDown<CR>", mode = "i", desc = "Tmux navigator" },
+      { "<S-Down>", "<CMD>NavigatorDown<CR>", mode = "n", desc = "Tmux navigator" },
+      { "<S-Left>", "<CMD>NavigatorLeft<CR>", mode = "i", desc = "Tmux navigator" },
+      { "<S-Left>", "<CMD>NavigatorLeft<CR>", mode = "n", desc = "Tmux navigator" },
+      { "<S-Right>", "<CMD>NavigatorRight<CR>", mode = "i", desc = "Tmux navigator" },
+      { "<S-Right>", "<CMD>NavigatorRight<CR>", mode = "n", desc = "Tmux navigator" },
+      { "<S-Up>", "<CMD>NavigatorUp<CR>", mode = "i", desc = "Tmux navigator" },
+      { "<S-Up>", "<CMD>NavigatorUp<CR>", mode = "n", desc = "Tmux navigator" },
+      { "<C-\\>", "<CMD>NavigatorPrevious<CR>", mode = "i", desc = "Tmux navigator (previous)" },
+      { "<C-\\>", "<CMD>NavigatorPrevious<CR>", mode = "n", desc = "Tmux navigator (previous)" },
+    },
     config = function()
       require("Navigator").setup({
         auto_save = "all",
         disable_on_zoom = true,
       })
-
-      local map = require("ik1614.functions.mapping")
-      map:n({ "<S-Left>", "<CMD>NavigatorLeft<CR>" })
-      map:n({ "<S-Right>", "<CMD>NavigatorRight<CR>" })
-      map:n({ "<S-Up>", "<CMD>NavigatorUp<CR>" })
-      map:n({ "<S-Down>", "<CMD>NavigatorDown<CR>" })
-      map:n({ "<C-\\>", "<CMD>NavigatorPrevious<CR>" })
-
-      map:i({ "<S-Left>", "<C-c><CMD>NavigatorLeft<CR>" })
-      map:i({ "<S-Right>", "<C-c><CMD>NavigatorRight<CR>" })
-      map:i({ "<S-Up>", "<C-c><CMD>NavigatorUp<CR>" })
-      map:i({ "<S-Down>", "<C-c><CMD>NavigatorDown<CR>" })
-      map:i({ "<C-\\>", "<C-c><CMD>NavigatorPrevious<CR>" })
     end,
   },
 }

--- a/dotfiles/nvim/lua/ik1614/plugins/treesitter.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/treesitter.lua
@@ -2,7 +2,8 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     enabled = true,
-    lazy = false,
+    event = { "BufReadPre", "BufNewFile" },
+    -- lazy = false,
     build = ":TSUpdate",
     dependencies = {
       "nvim-treesitter/nvim-treesitter-textobjects",


### PR DESCRIPTION
# Before
```
  This is more accurate than `nvim --startuptime`.
    LazyStart 16.56ms
    LazyDone  33.71ms (+17.15ms)
    UIEnter   93.07ms (+59.36ms)

    ...
    ● 🚀 startup 60.67ms
```

# After
```
  This is more accurate than `nvim --startuptime`.
    LazyStart 18.16ms
    LazyDone  35.27ms (+17.12ms)
    UIEnter   37.37ms (+2.09ms)
    ...
    ● 🚀 startup 19.67ms
```