### PR TITLE
chore(nvim): switch Python formatting and linting to `ruff`

### DIFF
--- a/dotfiles/nvim/lazy-lock.json
+++ b/dotfiles/nvim/lazy-lock.json
@@ -27,7 +27,7 @@
   "nvim-dap-python": { "branch": "master", "commit": "ae0225d0d4a46e18e6057ab3701ef87bbbd6aaad" },
   "nvim-dap-ui": { "branch": "master", "commit": "b7267003ba4dd860350be86f75b9d9ea287cedca" },
   "nvim-fzf": { "branch": "master", "commit": "c89b15aee136eeb4649901552da37a404415c356" },
-  "nvim-lint": { "branch": "master", "commit": "941fa1220a61797a51f3af9ec6b7d74c8c7367ce" },
+  "nvim-lint": { "branch": "master", "commit": "9dfb77ef6c5092a19502883c02dc5a02ec648729" },
   "nvim-lspconfig": { "branch": "master", "commit": "61e5109c8cf24807e4ae29813a3a82b31821dd45" },
   "nvim-nio": { "branch": "master", "commit": "7969e0a8ffabdf210edd7978ec954a47a737bbcc" },
   "nvim-tree.lua": { "branch": "master", "commit": "2086e564c4d23fea714e8a6d63b881e551af2f41" },

--- a/dotfiles/nvim/lua/ik1614/plugins/formatting.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/formatting.lua
@@ -26,7 +26,11 @@ return {
         end,
         formatters_by_ft = {
           lua = { "stylua" },
-          python = { "black" },
+          python = {
+            "ruff_fix", -- To fix auto-fixable lint errors
+            "ruff_format",
+            "ruff_organize_imports",
+          },
           hcl = { "hcl" },
           go = { "goimports-reviser", "gofumpt" },
         },

--- a/dotfiles/nvim/lua/ik1614/plugins/linting.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/linting.lua
@@ -1,12 +1,65 @@
+local error = vim.diagnostic.severity.ERROR
+
+local function setup_ruff(lint)
+  local severities = {
+    ["F821"] = error, -- undefined name `name`
+    ["E902"] = error, -- `IOError`
+    ["E999"] = error, -- `SyntaxError`
+  }
+
+  lint.linters.ruff = {
+    cmd = "ruff",
+    stdin = true,
+    args = {
+      "check",
+      "--force-exclude",
+      "--quiet",
+      "--stdin-filename",
+      vim.api.nvim_buf_get_name(0),
+      "--no-fix",
+      "--output-format",
+      "json",
+      "-",
+    },
+    ignore_exitcode = true,
+    stream = "stdout",
+    parser = function(output)
+      local diagnostics = {}
+      local ok, results = pcall(vim.json.decode, output)
+      if not ok then
+        return diagnostics
+      end
+      for _, result in ipairs(results or {}) do
+        local diagnostic = {
+          message = result.message,
+          col = result.location.column - 1,
+          end_col = result.end_location.column - 1,
+          lnum = result.location.row - 1,
+          end_lnum = result.end_location.row - 1,
+          code = result.code,
+          severity = severities[result.code] or vim.diagnostic.severity.WARN,
+          source = "ruff",
+        }
+        table.insert(diagnostics, diagnostic)
+      end
+      return diagnostics
+    end,
+  }
+end
+
 return {
   {
     "mfussenegger/nvim-lint",
     event = { "BufReadPre", "BufNewFile" },
     config = function()
       local lint = require("lint")
+
+      -- NOTE: For some reason `ruff` doesn't seem to work out of the box. Maybe because I have the old version of the plugin?
+      setup_ruff(lint)
+
       lint.linters_by_ft = {
         dockerfile = { "hadolint" },
-        python = { "flake8" },
+        python = { "ruff" },
       }
 
       local lint_augroup = vim.api.nvim_create_augroup("ik1614-linting", { clear = true })

--- a/dotfiles/nvim/lua/ik1614/plugins/linting.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/linting.lua
@@ -1,61 +1,9 @@
-local error = vim.diagnostic.severity.ERROR
-
-local function setup_ruff(lint)
-  local severities = {
-    ["F821"] = error, -- undefined name `name`
-    ["E902"] = error, -- `IOError`
-    ["E999"] = error, -- `SyntaxError`
-  }
-
-  lint.linters.ruff = {
-    cmd = "ruff",
-    stdin = true,
-    args = {
-      "check",
-      "--force-exclude",
-      "--quiet",
-      "--stdin-filename",
-      vim.api.nvim_buf_get_name(0),
-      "--no-fix",
-      "--output-format",
-      "json",
-      "-",
-    },
-    ignore_exitcode = true,
-    stream = "stdout",
-    parser = function(output)
-      local diagnostics = {}
-      local ok, results = pcall(vim.json.decode, output)
-      if not ok then
-        return diagnostics
-      end
-      for _, result in ipairs(results or {}) do
-        local diagnostic = {
-          message = result.message,
-          col = result.location.column - 1,
-          end_col = result.end_location.column - 1,
-          lnum = result.location.row - 1,
-          end_lnum = result.end_location.row - 1,
-          code = result.code,
-          severity = severities[result.code] or vim.diagnostic.severity.WARN,
-          source = "ruff",
-        }
-        table.insert(diagnostics, diagnostic)
-      end
-      return diagnostics
-    end,
-  }
-end
-
 return {
   {
     "mfussenegger/nvim-lint",
     event = { "BufReadPre", "BufNewFile" },
     config = function()
       local lint = require("lint")
-
-      -- NOTE: For some reason `ruff` doesn't seem to work out of the box. Maybe because I have the old version of the plugin?
-      setup_ruff(lint)
 
       lint.linters_by_ft = {
         dockerfile = { "hadolint" },

--- a/dotfiles/nvim/lua/ik1614/plugins/lsp.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/lsp.lua
@@ -41,6 +41,7 @@ return {
         virtual_text = {
           spacing = 4,
           prefix = "●",
+          source = "if_many",
         },
         float = { border = "rounded" },
       })
@@ -141,13 +142,20 @@ return {
             -- TODO: implement fall back to the system defaults
             config.settings.python.pythonPath = p
           end,
+          pyright = {
+            disableOrganizeImports = true, -- Using Ruff's import organizer
+          },
           python = {
             settings = {
+              -- Defaults ---> https://microsoft.github.io/pyright/#/configuration?id=diagnostic-settings-defaults
               reportUnusedImport = true,
               reportUnusedVariable = true,
               reportDuplicateImport = true,
               reportDeprecated = true,
               reportUnnecessaryTypeIgnoreComment = true,
+            },
+            analyses = {
+              ignore = { "*" },
             },
           },
         },
@@ -186,21 +194,17 @@ return {
 
       mason_tool_installer.setup({
         ensure_installed = {
-          "black",
           "debugpy",
           "delve",
           "doctoc",
           "eslint_d",
-          "flake8",
           "gofumpt",
           "goimports-reviser",
           "gopls",
           "hadolint",
           "hclfmt",
-          "isort",
           "lua_ls",
           "prettier",
-          "pylint",
           "pyright",
           "stylua",
           "typescript-language-server",

--- a/dotfiles/nvim/lua/ik1614/plugins/statusine.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/statusine.lua
@@ -42,25 +42,41 @@ return {
           return msg
         end
 
+        local lsp_info = {}
         for _, client in pairs(buf_clients) do
-          table.insert(info, client.name)
+          table.insert(lsp_info, client.name)
         end
 
+        if next(lsp_info) ~= nil then
+          table.insert(info, "LSP: " .. table.concat(lsp_info, ", "))
+        end
+
+        -- NOTE: This feels a bit useless as we get linters only while they are running
+        local linter_info = {}
         for _, linter in pairs(buf_linters) do
-          table.insert(info, linter.name)
+          table.insert(linter_info, linter.name)
         end
 
+        if next(linter_info) ~= nil then
+          table.insert(info, "Lint: " .. table.concat(lsp_info, ", "))
+        end
+
+        local formatter_info = {}
         if formatting.enabled_on_save then
           for _, formatter in pairs(buf_formatters) do
-            table.insert(info, formatter.name)
+            table.insert(formatter_info, formatter.name)
           end
+        end
+
+        if next(formatter_info) ~= nil then
+          table.insert(info, "Format: " .. table.concat(formatter_info, ", "))
         end
 
         if next(info) == nil then
           return ""
         end
 
-        return "LSP: " .. table.concat(info, ", ")
+        return table.concat(info, " | ")
       end
 
       local lualine_a = {

--- a/dotfiles/nvim/lua/ik1614/plugins/statusine.lua
+++ b/dotfiles/nvim/lua/ik1614/plugins/statusine.lua
@@ -64,7 +64,15 @@ return {
         local formatter_info = {}
         if formatting.enabled_on_save then
           for _, formatter in pairs(buf_formatters) do
-            table.insert(formatter_info, formatter.name)
+            if string.sub(formatter.name, 1, #"ruff") == "ruff" then
+              local name = "ruff"
+              if not formatter_info[name] then
+                table.insert(formatter_info, name)
+                formatter_info[name] = true
+              end
+            else
+              table.insert(formatter_info, formatter.name)
+            end
           end
         end
 


### PR DESCRIPTION
It seems to work better via `nvim-lint` instead of native [ruff LSP](https://docs.astral.sh/ruff/editors/setup/#neovim). However, this doesn't offer code actions, e.g. in-line exclude of a rule.